### PR TITLE
fix(pagination): pagination now orders ascending by timestamp

### DIFF
--- a/src/web_server/app.js
+++ b/src/web_server/app.js
@@ -99,7 +99,7 @@ router.get('/properties', async ctx => {
 
         // Consultar propiedades filtradas con paginación
         const result = await ctx.app.pool.query(
-            `SELECT * FROM properties ${whereSQL} ORDER BY (data->>'timestamp')::timestamp DESC LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`,
+            `SELECT * FROM properties ${whereSQL} ORDER BY (data->>'timestamp')::timestamp ASC LIMIT $${queryParams.length + 1} OFFSET $${queryParams.length + 2}`,
             [...queryParams, parseInt(limit), parseInt(offset)]
         );
 


### PR DESCRIPTION
that way, page 1 returns the oldest entries and so on